### PR TITLE
BF: conda -- activate base environment upon sourcing conda profile

### DIFF
--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -822,6 +822,7 @@ class MinicondaComponent(Component):
             CondaInstaller(self.manager, conda_instance)
         )
         self.manager.addenv(f"source {shlex.quote(str(path))}/etc/profile.d/conda.sh")
+        self.manager.addenv("conda activate base")
 
 
 @DataladInstaller.register_component("conda-env")


### PR DESCRIPTION
as I just discovered recently, such `source` of that profile does not place
`bin/` of the base environment into the PATH.  It would place only `condabin/`
which would have only `conda` and nothing installed (possibly with subsequent
conda install) in the base environment.  Following up that source with
`conda activate base` should mitigate the issue

Here is how it works with master version:

	$> bash -c 'source /home/yoh/.tmp/dl-env-6luguo2u.sh; which git-annex'
	/usr/bin/git-annex

	$> bash -c 'source /home/yoh/.tmp/dl-env-6luguo2u.sh; conda activate base; which git-annex'
	/tmp/testmini/bin/git-annex

and it is all good with this PR version

```
$> bash -c 'source /home/yoh/.tmp/dl-env-7fiqnklq.sh; which git-annex'
/tmp/testmini/bin/git-annex

$> cat /home/yoh/.tmp/dl-env-7fiqnklq.sh                              
source /tmp/testmini/etc/profile.d/conda.sh
conda activate base
```

