### PR TITLE
Move TMPDIR setting on Windows to run-tests.sh

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,13 +50,6 @@ jobs:
           python -m pip install --upgrade pip wheel
           python -m pip install --upgrade --upgrade-strategy=eager tox
 
-      - name: Set TMPDIR to C:\tmp on Windows
-        # To avoid <https://github.com/conda/conda/issues/10501>
-        if: startsWith(matrix.os, 'windows')
-        run: |
-          mkdir -p /c/tmp
-          printf 'TMPDIR=%s\n' 'C:\tmp' >> "$GITHUB_ENV"
-
       - name: Run tests
         if: matrix.toxenv == 'py'
         run: ./run-tests.sh -e py -- --cov-report=xml

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
-if [ "$(uname)" = Darwin ]
-then
-    # The lengthy default $TMPDIR on macOS causes lengthy shebangs when
-    # installing Miniconda.  If the shebang exceeds 127 characters, Miniconda
-    # refuses to use it, instead setting the first line of the "conda" script
-    # to "#!/usr/bin/env python", which results in a non-working installation.
-    # Hence, we need a shorter $TMPDIR.
-    export TMPDIR=/tmp
-fi
+case "$(uname)" in
+    Darwin)
+        # The lengthy default $TMPDIR on macOS causes lengthy shebangs when
+        # installing Miniconda.  If the shebang exceeds 127 characters,
+        # Miniconda refuses to use it, instead setting the first line of the
+        # "conda" script to "#!/usr/bin/env python", which results in a
+        # non-working installation.  Hence, we need a shorter $TMPDIR.
+        #
+        # Related issue: <https://github.com/conda/conda/issues/9360>
+        export TMPDIR=/tmp
+        ;;
+    MINGW*)
+        # To avoid <https://github.com/conda/conda/issues/10501>
+        mkdir -p /c/tmp
+        export TMPDIR='C:\tmp'
+        ;;
+esac
 
 exec tox "$@"


### PR DESCRIPTION
As requested [here](https://github.com/datalad/datalad-installer/pull/17#discussion_r574156862).