### PR TITLE
Set up auto

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,0 +1,16 @@
+{
+    "onlyPublishWithReleaseLabel": true,
+    "baseBranch": "master",
+    "author": "auto <auto@nil>",
+    "noVersionPrefix": true,
+    "plugins": [
+        "git-tag",
+        [
+            "exec",
+            {
+                "afterChangelog": "bump2version \"$(printf '%s\n' \"$ARG_0\" | jq -r .bump)\"",
+                "afterRelease": "python -m build && twine upload dist/*"
+            }
+        ]
+    ]
+}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,7 @@
+[bumpversion]
+current_version = 0.1.0
+commit = True
+message = [skip ci] Bump version: {current_version} → {new_version}
+tag = False
+
+[bumpversion:file:src/datalad_installer.py]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Auto-release on PR merge
+
+on:
+  # ATM, this is the closest trigger to a PR merging
+  push:
+    branches:
+      - master
+
+jobs:
+  auto-release:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Download auto
+        run: |
+          #curl -vL -o - "$(curl -fsSL https://api.github.com/repos/intuit/auto/releases/latest | jq -r '.assets[] | select(.name == "auto-linux.gz") | .browser_download_url')" | gunzip > ~/auto
+          # Pin to 10.16.1 so we don't break if & when
+          # <https://github.com/intuit/auto/issues/1778> is fixed.
+          wget -O- https://github.com/intuit/auto/releases/download/v10.16.1/auto-linux.gz | gunzip > ~/auto
+          chmod a+x ~/auto
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '^3.6'
+
+      - name: Install Python dependencies
+        run: python -m pip install build bump2version twine
+
+      - name: Create release
+        run: ~/auto shipit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+
+# vim:set sts=2:


### PR DESCRIPTION
Closes #5.

This PR also needs to be accompanied by the following changes:
- [x] Create the necessary labels for `auto` by running `GH_TOKEN=... auto create-labels` in a copy of this repository containing `.autorc`
- [x] A GitHub release must be created for the most recent version of datalad-installer
- [x] An auth token for uploading assets for the `datalad-installer` project to PyPI must be saved as a secret named "`PYPI_TOKEN`"