### PR TITLE
Support installing Datalad with brew

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -198,6 +198,7 @@ Installs Datalad_.  The component takes an ``-m``, ``--method`` option
 specifying the installation method to use; the supported methods are:
 
 - ``apt``
+- ``brew``
 - ``conda``
 - ``deb-url``
 - ``pip``

--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -1164,6 +1164,7 @@ class AptInstaller(Installer):
             raise MethodNotSupportedError("apt-get command not found")
 
 
+@DataladComponent.register_installer
 @GitAnnexComponent.register_installer
 class HomebrewInstaller(Installer):
     """ Installs via brew (Homebrew) """
@@ -1175,6 +1176,7 @@ class HomebrewInstaller(Installer):
     ]
 
     PACKAGES = {
+        "datalad": ("datalad", ["datalad"]),
         "git-annex": ("git-annex", ["git-annex"]),
     }
 


### PR DESCRIPTION
[Datalad is in Homebrew now](https://github.com/Homebrew/homebrew-core/pull/70835), so datalad-installer can now install it with `brew`.