### PR TITLE
Mark conda on Windows & macOS as an unsupported method for installing git-annex

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,7 @@ specifying the installation method to use; the supported methods are:
 - ``apt``
 - ``autobuild``
 - ``brew``
-- ``conda`` (not supported on Windows)
+- ``conda`` (only supported on Linux)
 - ``datalad/git-annex``
 - ``deb-url``
 - ``neurodebian``

--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,7 @@ specifying the installation method to use; the supported methods are:
 - ``apt``
 - ``autobuild``
 - ``brew``
-- ``conda``
+- ``conda`` (not supported on Windows)
 - ``datalad/git-annex``
 - ``deb-url``
 - ``neurodebian``

--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -1473,9 +1473,9 @@ class CondaInstaller(Installer):
         extra_args: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> Path:
-        if package == "git-annex" and platform.system() == "Windows":
+        if package == "git-annex" and platform.system() != "Linux":
             raise MethodNotSupportedError(
-                "Conda does not support installing git-annex on Windows"
+                "Conda only supports installing git-annex on Linux"
             )
         log.info("Installing %s via conda", package)
         if self.conda_instance is not None:

--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -1473,6 +1473,10 @@ class CondaInstaller(Installer):
         extra_args: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> Path:
+        if package == "git-annex" and platform.system() == "Windows":
+            raise MethodNotSupportedError(
+                "Conda does not support installing git-annex on Windows"
+            )
         log.info("Installing %s via conda", package)
         if self.conda_instance is not None:
             conda = self.conda_instance


### PR DESCRIPTION
Part of #3.