### PR TITLE
Use pip to correctly determine pip's script install path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
           - python-version: '3.6'
             toxenv: typing
             os: ubuntu-latest
+          - python-version: '3.6'
+            toxenv: py-pipdev
+            os: ubuntu-latest
         exclude:
           # venv seems to be broken on pypy3 under Windows.
           - python-version: 'pypy3'

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
     flake8-bugbear
     flake8-builtins~=1.4
     flake8-import-order-jwodder
+    pipdev: pip @ git+https://github.com/pypa/pip
     pytest~=6.0
     pytest-cov~=2.0
 commands =


### PR DESCRIPTION
Fixes #18.

This PR relies on using an internal pip API that the pip developers don't want outsiders to rely on.  (Fortunately, the particular function used has been stable for many pip versions.)  The alternative would be to copy the function's implementation, but that relies on distutils, which is in the process of being removed from the standard library and moved into setuptools.