### PR TITLE
.autorc: Set "noVersionPrefix" to `false`

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -2,7 +2,7 @@
     "onlyPublishWithReleaseLabel": true,
     "baseBranch": "master",
     "author": "auto <auto@nil>",
-    "noVersionPrefix": true,
+    "noVersionPrefix": false,
     "plugins": [
         "git-tag",
         [


### PR DESCRIPTION
For consistency with pre-existing tags