### PR TITLE
Use "sudo" to install neurodebian

### DIFF
--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -956,6 +956,7 @@ class NeurodebianComponent(Component):
         if kwargs:
             log.warning("Ignoring extra component arguments: %r", kwargs)
         runcmd(
+            "sudo",
             "apt-get",
             "install",
             "-qy",


### PR DESCRIPTION
Closes #31.