### PR TITLE
Print brew diagnostic output on failure

### DIFF
--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -1291,7 +1291,15 @@ class HomebrewInstaller(Installer):
         if extra_args:
             cmd.extend(extra_args)
         cmd.append(package)
-        runcmd(*cmd)
+        try:
+            runcmd(*cmd)
+        except subprocess.CalledProcessError:
+            log.error(
+                "brew command failed; printing diagnostic output for reporting issue"
+            )
+            runcmd("brew", "config")
+            runcmd("brew", "doctor")
+            raise
         ### TODO: Handle variations in this path (Is it "$(brew --prefix)/bin"?)
         log.debug("Installed program directory: /usr/local/bin")
         return Path("/usr/local/bin")


### PR DESCRIPTION
Closes #50.

I went with `brew config` & `brew doctor` over `brew gist-logs` because (a) `brew gist-logs` will fail unless a GitHub token is set in a certain environment variable, and (b) I don't know which formula `brew gist-logs` should be executed for in the event that installing a dependency of a requested formula fails.