### PR TITLE
[DATALAD RUNCMD] codespell is lucky to find a typo

### DIFF
--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -1422,7 +1422,7 @@ class PipInstaller(Installer):
 
     def assert_supported_system(self) -> None:
         ### TODO: Detect whether pip is installed in the current Python,
-        ### preferrably without importing it
+        ### preferably without importing it
         pass
 
 


### PR DESCRIPTION
but it is primarily to test appveyor

=== Do not change lines below ===
{
 "chain": [],
 "cmd": "codespell -w",
 "exit": 0,
 "extra_inputs": [],
 "inputs": [],
 "outputs": [],
 "pwd": "."
}
^^^ Do not change lines above ^^^