### PR TITLE
Delete a certain tempfile once we're done with it

### DIFF
--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -1415,8 +1415,11 @@ class PipInstaller(Installer):
                 file=script,
                 flush=True,
             )
+            # We need to close before passing to Python for Windows
+            # compatibility
             script.close()
             binpath = Path(readcmd(self.python, script.name))
+            os.unlink(script.name)
         log.debug("Installed program directory: %s", binpath)
         return binpath
 


### PR DESCRIPTION
For Windows reasons, the tempfile in question has to be closed before executing it, so I set `delete=True` so it wouldn't be deleted on closure, but it turns out that also keeps it from being deleted when the context manager exits.  This PR explicitly deletes the file when we're done with it.