### PR TITLE
Use newer build for OSX (from Catalina on GH actions, instead of Yosemite)

### DIFF
--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -1589,7 +1589,7 @@ class SnapshotInstaller(AutobuildSnapshotInstaller):
         if ON_LINUX:
             binpath = self._install_linux("linux/current")
         elif ON_MACOS:
-            binpath = self._install_macos("OSX/current/10.10_Yosemite")
+            binpath = self._install_macos("OSX/current/10.15_Catalina")
         else:
             raise AssertionError("Method should not be called on unsupported platforms")
         log.debug("Installed program directory: %s", binpath)


### PR DESCRIPTION
Damn me forgot that I agreed with @joeyh that we should abandon builds from elderly imac which used to seat in my office and switch to the builds which @joeyh fetches from con/tinuous archive of datalad/git-annex