### PR TITLE
Ensure the pip version in venvs is up-to-date

### DIFF
--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -849,6 +849,9 @@ class VenvComponent(Component):
                 "install",
                 "pip @ git+https://github.com/pypa/pip",
             )
+        else:
+            # Ensure we have a recent pip
+            runcmd(installer.python, "-m", "pip", "install", "--upgrade", "pip")
         self.manager.installer_stack.append(installer)
 
 

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import shlex
 import shutil
 import subprocess
+import sys
 import tempfile
 import pytest
 import datalad_installer
@@ -225,6 +226,9 @@ def test_install_venv_datalad(tmp_path):
     assert (venv_path / bin_path("datalad")).exists()
 
 
+@pytest.mark.skipif(
+    sys.version_info[:2] < (3, 7), reason="dev pip no longer supports Python < 3.7"
+)
 def test_install_venv_dev_pip_datalad(tmp_path):
     venv_path = tmp_path / "venv"
     r = main(


### PR DESCRIPTION
CI tests on Windows with Python 3.6 have been failing for the past few days due to an inability to build pynacl from source when installing datalad in venvs created by datalad-installer.  Based on [this issue](https://github.com/pyca/pynacl/issues/746), it appears that this should be resolved by ensuring that the venvs have an up-to-date version of pip in them, and so this PR does that.