### PR TITLE
Mark some tests as impossible to pass on conda-forge

### DIFF
--- a/test/test_install.py
+++ b/test/test_install.py
@@ -415,6 +415,7 @@ def test_install_git_annex_remote_rclone_specific_version_from_github(
 
 
 @pytest.mark.ci_only
+@pytest.mark.needs_sudo
 @pytest.mark.skipif(not ON_POSIX, reason="POSIX only")
 def test_install_git_annex_remote_rclone_latest_from_github_globally() -> None:
     r = main(
@@ -525,6 +526,7 @@ def test_install_rclone_version_from_downloads(
 
 
 @pytest.mark.ci_only
+@pytest.mark.needs_sudo
 @pytest.mark.skipif(not ON_POSIX, reason="POSIX only")
 def test_install_latest_rclone_from_downloads_globally(mocker: MockerFixture) -> None:
     spy = mocker.spy(datalad_installer, "runcmd")

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ markers =
     ci_only: Only run when --ci is given
     ghauth: May use GitHub token
     miniconda: Installs miniconda
+    needs_sudo: Requires passwordless sudo
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
The latest PR to update the conda-forge recipe (https://github.com/conda-forge/datalad-installer-feedstock/pull/4) is currently failing because two of the tests require passwordless sudo to work, which conda-forge's CI environment does not provide.  This PR marks the tests as not passable on conda-forge.

After this PR is merged & released, the pytest commands in `recipe/test.{sh,bat}` in the feedstock will need to be updated to use `-m "not miniconda and not needs_sudo"` instead of just `-m "not miniconda"`.