### PR TITLE
Use GitHub token when downloading workflow artifacts

### DIFF
--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -1870,7 +1870,9 @@ class DataladGitAnnexBuildInstaller(Installer):
             raise MethodNotSupportedError(f"{SYSTEM} OS not supported")
 
     @staticmethod
-    def download(ostype: str, target_dir: Path, _version: Optional[str] = None) -> None:
+    def download(
+        ostype: str, target_dir: Path, version: Optional[str]  # noqa: U100
+    ) -> None:
         """
         Download & unzip the artifact from the latest successful build of
         datalad/git-annex for the given OS in the given directory
@@ -1890,7 +1892,9 @@ class DataladGitAnnexLatestBuildInstaller(DataladGitAnnexBuildInstaller):
     NAME = "datalad/git-annex"
 
     @staticmethod
-    def download(ostype: str, target_dir: Path, _version: Optional[str] = None) -> None:
+    def download(
+        ostype: str, target_dir: Path, version: Optional[str]  # noqa: U100
+    ) -> None:
         """
         Download & unzip the artifact from the latest build of
         datalad/git-annex for the given OS in the given directory

--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -2250,7 +2250,7 @@ class GitHubClient:
             archive_download_url = self.get_archive_download_url(artifacts_url)
             if archive_download_url is not None:
                 log.info("Downloading artifact package from %s", archive_download_url)
-                download_zipfile(archive_download_url, target_dir)
+                download_zipfile(archive_download_url, target_dir, headers=self.headers)
                 return
         else:
             raise RuntimeError("No workflow runs with artifacts found!")
@@ -2272,7 +2272,7 @@ class GitHubClient:
             archive_download_url = self.get_archive_download_url(artifacts_url)
             if archive_download_url is not None:
                 log.info("Downloading artifact package from %s", archive_download_url)
-                download_zipfile(archive_download_url, target_dir)
+                download_zipfile(archive_download_url, target_dir, headers=self.headers)
                 return
         else:
             raise RuntimeError("No workflow runs with artifacts found!")

--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -1870,7 +1870,7 @@ class DataladGitAnnexBuildInstaller(Installer):
             raise MethodNotSupportedError(f"{SYSTEM} OS not supported")
 
     @staticmethod
-    def download(ostype: str, target_dir: Path, _version: Optional[str]) -> None:
+    def download(ostype: str, target_dir: Path, _version: Optional[str] = None) -> None:
         """
         Download & unzip the artifact from the latest successful build of
         datalad/git-annex for the given OS in the given directory
@@ -1890,7 +1890,7 @@ class DataladGitAnnexLatestBuildInstaller(DataladGitAnnexBuildInstaller):
     NAME = "datalad/git-annex"
 
     @staticmethod
-    def download(ostype: str, target_dir: Path, _version: Optional[str]) -> None:
+    def download(ostype: str, target_dir: Path, _version: Optional[str] = None) -> None:
         """
         Download & unzip the artifact from the latest build of
         datalad/git-annex for the given OS in the given directory

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -14,6 +14,8 @@ from datalad_installer import (
     ON_MACOS,
     ON_POSIX,
     ON_WINDOWS,
+    DataladGitAnnexBuildInstaller,
+    DataladGitAnnexLatestBuildInstaller,
     DataladGitAnnexReleaseBuildInstaller,
     main,
 )
@@ -328,6 +330,42 @@ def test_install_git_annex_brew(mocker: MockerFixture) -> None:
     assert r == 0
     assert spy.call_args_list[-1] == mocker.call("brew", "install", "git-annex")
     assert shutil.which("git-annex") is not None
+
+
+@pytest.mark.ghauth_required
+@pytest.mark.parametrize(
+    "ostype,ext",
+    [
+        ("ubuntu", ".deb"),
+        ("macos", ".dmg"),
+        ("windows", ".exe"),
+    ],
+)
+def test_download_git_annex_tested_artifact(
+    ostype: str, ext: str, tmp_path: Path
+) -> None:
+    DataladGitAnnexBuildInstaller.download(ostype=ostype, target_dir=tmp_path)
+    (p,) = tmp_path.glob(f"*{ext}")
+    assert p.is_file()
+    assert p.stat().st_size >= (1 << 20)  # 1 MiB
+
+
+@pytest.mark.ghauth_required
+@pytest.mark.parametrize(
+    "ostype,ext",
+    [
+        ("ubuntu", ".deb"),
+        ("macos", ".dmg"),
+        ("windows", ".exe"),
+    ],
+)
+def test_download_git_annex_latest_artifact(
+    ostype: str, ext: str, tmp_path: Path
+) -> None:
+    DataladGitAnnexLatestBuildInstaller.download(ostype=ostype, target_dir=tmp_path)
+    (p,) = tmp_path.glob(f"*{ext}")
+    assert p.is_file()
+    assert p.stat().st_size >= (1 << 20)  # 1 MiB
 
 
 @pytest.mark.ghauth

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -338,7 +338,11 @@ def test_install_git_annex_brew(mocker: MockerFixture) -> None:
     [
         ("ubuntu", ".deb"),
         ("macos", ".dmg"),
-        ("windows", ".exe"),
+        pytest.param(
+            "windows",
+            ".exe",
+            marks=pytest.mark.xfail(reason="No successful Windows builds in months"),
+        ),
     ],
 )
 def test_download_git_annex_tested_artifact(

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -348,7 +348,9 @@ def test_install_git_annex_brew(mocker: MockerFixture) -> None:
 def test_download_git_annex_tested_artifact(
     ostype: str, ext: str, tmp_path: Path
 ) -> None:
-    DataladGitAnnexBuildInstaller.download(ostype=ostype, target_dir=tmp_path)
+    DataladGitAnnexBuildInstaller.download(
+        ostype=ostype, target_dir=tmp_path, version=None
+    )
     (p,) = tmp_path.glob(f"*{ext}")
     assert p.is_file()
     assert p.stat().st_size >= (1 << 20)  # 1 MiB
@@ -366,7 +368,9 @@ def test_download_git_annex_tested_artifact(
 def test_download_git_annex_latest_artifact(
     ostype: str, ext: str, tmp_path: Path
 ) -> None:
-    DataladGitAnnexLatestBuildInstaller.download(ostype=ostype, target_dir=tmp_path)
+    DataladGitAnnexLatestBuildInstaller.download(
+        ostype=ostype, target_dir=tmp_path, version=None
+    )
     (p,) = tmp_path.glob(f"*{ext}")
     assert p.is_file()
     assert p.stat().st_size >= (1 << 20)  # 1 MiB

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ norecursedirs = test/data
 markers =
     ci_only: Only run when --ci is given
     ghauth: May use GitHub token
+    ghauth_required: Requires GitHub token
     miniconda: Installs miniconda
     needs_sudo: Requires passwordless sudo
 


### PR DESCRIPTION
Fixes the problem reported in https://github.com/datalad/datalad-extensions/issues/101.

Note that the test of `git-annex:tested` for Windows had to be marked as xfailing because there hasn't been a successful Windows build of datalad/git-annex for four months, and so the latest run's artifacts have expired.