### PR TITLE
Make `OSError.winerror` reference portable

### DIFF
--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -656,7 +656,7 @@ class DataladInstaller:
         try:
             runcmd(*args, **kwargs)
         except OSError as e:
-            if e.winerror == 740:  # type: ignore[attr-defined]
+            if getattr(e, "winerror", None) == 740:
                 log.info("Operation requires elevation; rerunning as administrator")
                 self.sudo(*args, **kwargs)
             else:


### PR DESCRIPTION
Apparently, OSError only has a `winerror` attribute on Windows, so we need to use `getattr()` for support on other platforms.