### PR TITLE
Fix test failures due to some sort of dependency hell

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,9 @@ minversion = 3.3.0
 # HOME needs to be set in order for brew to work:
 passenv = GITHUB_TOKEN HOME
 deps =
-    pytest~=7.0
-    pytest-cov~=3.0
-    pytest-mock~=3.0
+    pytest
+    pytest-cov
+    pytest-mock
 commands =
     pytest {posargs} test
 


### PR DESCRIPTION
The latest version of pytest isn't compatible with pytest-cov 3.x.  It is compatible with pytest-cov 4.x, but we were restricting the pytest-cov version.  This PR fixes the test dependencies to always use the latest versions of each project.