### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -93,12 +93,6 @@ environment:
       INSTALL_GITANNEX: git-annex
 
     # Test alternative Python versions
-    - ID: Ubu20P36
-      PY: 3.6
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
-      INSTALL_SYSPKGS: python3-virtualenv
-      # system git-annex is way too old, use better one
-      INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20201228T023115Z/pool/main/g/git-annex/git-annex_8.20201127-1_amd64.deb
     - ID: Ubu20P37
       PY: 3.7
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '^3.6'
+          python-version: '^3.7'
 
       - name: Install Python dependencies
         run: python -m pip install build bump2version twine

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
           - windows-latest
           - ubuntu-latest
         python-version:
-          - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'
@@ -32,10 +31,10 @@ jobs:
           - 'pypy-3.7'
         toxenv: [py]
         include:
-          - python-version: '3.6'
+          - python-version: '3.7'
             toxenv: lint
             os: ubuntu-latest
-          - python-version: '3.6'
+          - python-version: '3.7'
             toxenv: typing
             os: ubuntu-latest
         exclude:

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Python libraries, though it does make heavy use of external packaging commands.
 
 Installation
 ============
-``datalad-installer`` requires Python 3.6 or higher.  Just use `pip
+``datalad-installer`` requires Python 3.7 or higher.  Just use `pip
 <https://pip.pypa.io>`_ for Python 3 (You have pip, right?) to install it::
 
     python3 -m pip install datalad-installer

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ classifiers =
     #Development Status :: 5 - Production/Stable
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -53,7 +52,7 @@ py_modules = datalad_installer
 package_dir =
     =src
 include_package_data = True
-python_requires = ~= 3.6
+python_requires = ~= 3.7
 
 [options.entry_points]
 console_scripts =

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -59,10 +59,6 @@ def test_install_miniconda(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(
-    sys.version_info[:2] < (3, 7),
-    reason="Trying to install Python 3.6 on Conda gives package conflicts",
-)
-@pytest.mark.skipif(
     sys.version_info[:2] == (3, 11),
     reason="Python 3.11 not yet available on Conda",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,typing,py36,py37,py38,py39,py310,py311,pypy3
+envlist = lint,typing,py37,py38,py39,py310,py311,pypy3
 skip_missing_interpreters = True
 isolated_build = True
 minversion = 3.3.0


### PR DESCRIPTION
Python 3.6 has been EOL for over a year, and GitHub Actions no longer provides it for Ubuntu.