### PR TITLE
Support installing from datalad/packages on Linux

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -461,7 +461,15 @@ Supports installing specific versions (though note that the version strings for
 this method tend to include Git commit information, e.g.,
 "``8.20210127+git111-gbe5a0e4b8``").
 
-This installation method is only supported on Windows and macOS.
+Options
+'''''''
+
+--install-dir DIR               Directory in which to unpack the ``*.deb``
+                                package instead of installing it system-wide.
+                                If this contains the string ``{tmpdir}``, it
+                                will be replaced with the path to a directory
+                                in ``$TMPDIR``. (Linux only)
+
 
 ``deb-url``
 ~~~~~~~~~~~


### PR DESCRIPTION
Closes #142.

This will not work until the packages in https://datasets.datalad.org/?dir=/datalad/packages/neurodebian are renamed to use `~ndall` instead of `.ndall`.