### PR TITLE
Cancel any still-running tests when pushing to a branch or PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
If a commit is pushed while tests are still running on that branch, the older tests will currently continue to run to completion, likely delaying the start of the tests for the newer commit.  This PR causes any still-running tests to be automatically cancelled when new tests start on the same branch.