### PR TITLE
Provide explicit release to nd-configure if it fails to determine one, specify minimal version of datalad (>= 0.10.0) for conda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .cache/
 .coverage*
 .eggs/
+.idea/
 .mypy_cache/
 .nox/
 .pytest_cache/
@@ -14,3 +15,4 @@ dist/
 docs/.doctrees/
 docs/_build/
 venv/
+venvs/

--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -1265,19 +1265,6 @@ class NeurodebianComponent(Component):
                     args = (extra_args or []) + ["-r", version_codename, "--overwrite"]
                     runcmd("nd-configurerepo", *args)
                     return
-
-                    # # we will not rely on "line" in the message and just go through the lines
-                    # # and see if any need to be fixed.
-                    # apt_lines = apt_file.read_text('utf-8').splitlines()
-                    # line_fixed = None
-                    # for i, line in enumerate(apt_lines):
-                    #     line_split = line.strip().split()
-                    #     if len(line_split) == 3 and line_split[0] in ('deb', 'deb-src'):
-                    #         line_fixed = ' '.join(line_split[:2] + [version_codename] + line_split[2:])
-                    #         log.info("Found malformed line #%d. Fixing '%s' to '%s'", i, line, line_fixed)
-                    #         apt_lines[i] = line_fixed
-                    # if line_fixed:
-                    #     apt_file.write_text(os.linesep.join(apt_lines))
             raise
 
 

--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -1243,8 +1243,8 @@ class NeurodebianComponent(Component):
         )
         try:
             runcmd("nd-configurerepo", *(extra_args or []))
-        except subprocess.CalledProcessError as exc:
-            if apt_file.exists() and ("Malformed entry" in exc.stderr):
+        except subprocess.CalledProcessError:  #  as exc:
+            if apt_file.exists():  #  and ("Malformed entry" in exc.stderr):
                 log.info(
                     "DEBUG information for the error, the content of %s:\n%s",
                     apt_file,

--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -1915,7 +1915,12 @@ class CondaInstaller(Installer):
         if extra_args is not None:
             cmd.extend(extra_args)
         if version is None:
-            cmd.append(package)
+            # Ad-hoc workaround for https://github.com/conda-forge/datalad-feedstock/issues/109
+            # we need to request datalad after 'noarch' 0.9.3
+            if package == "datalad":
+                cmd.append("datalad>=0.10.0")
+            else:
+                cmd.append(package)
         else:
             cmd.append(f"{package}={version}")
         i = 0


### PR DESCRIPTION
This should address the problems for using datalad-installer on github actions in `ubuntu-latest`