### PR TITLE
Remove inapplicable installers from datalad's "auto" resolution list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -269,10 +269,7 @@ component from the following list will be used:
 
 - ``conda``
 - ``apt``
-- ``neurodebian``
 - ``brew``
-- ``autobuild``
-- ``datalad/packages``
 
 A specific version to install can be specified for those methods that support
 it by suffixing "``datalad``" with "``=``" and the version number on the


### PR DESCRIPTION
The README's description of the "auto" installation method for datalad included several components that do not apply to datalad (likely due to copy & paste from the git-annex section).  This PR removes them.