### PR TITLE
Always provide -y   to apt-get install

### DIFF
--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -1545,7 +1545,7 @@ class AptInstaller(Installer):
         if build_dep:
             cmd.append("build-dep")
         else:
-            cmd.append("install")
+            cmd.extend(["install", "-y"])
         if extra_args:
             cmd.extend(extra_args)
         if version is not None:


### PR DESCRIPTION
Ref: workaround was attempted at https://github.com/neuronets/datalad-action/pull/1/files

Origin: trying to use datalad-installer on a pristine'ish Debian AMI on AWS.

- [x] confirm that solves the issue for @hvgazula @aaronkanzer

note: next aspect is that while trying on that AMI -- it failed to install because there were no prior `apt-get update` run and some package information was outdated. But it is a separate issue