### PR TITLE
Make compatible with arm64 brew, test on older and latest macos, strip away no longer needed windows test env exclusion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - macos-12
           - macos-latest
           - windows-latest
           - ubuntu-latest
@@ -37,6 +38,18 @@ jobs:
           - 'pypy-3.9'
           - 'pypy-3.10'
         toxenv: [py]
+        exclude:
+          # No older Pythons on arm64 macos-latest
+          - python-version: '3.7'
+            os: macos-latest
+          - python-version: '3.8'
+            os: macos-latest
+          - python-version: '3.9'
+            os: macos-latest
+          - python-version: 'pypy-3.8'
+            os: macos-latest
+          - python-version: 'pypy-3.9'
+            os: macos-latest
         include:
           - python-version: '3.7'
             toxenv: lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,11 +44,6 @@ jobs:
           - python-version: '3.7'
             toxenv: typing
             os: ubuntu-latest
-        exclude:
-          # venv seems to be broken on pypy3 under Windows.
-          - python-version: 'pypy-3.7'
-            toxenv: py
-            os: windows-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -28,7 +28,7 @@ from dataclasses import InitVar, dataclass, field
 from email import policy
 from email.headerregistry import ContentTypeHeader
 from enum import Enum
-from functools import cached_property, total_ordering
+from functools import lru_cache, total_ordering
 from getopt import GetoptError, getopt
 from html.parser import HTMLParser
 from http.client import HTTPMessage
@@ -1585,10 +1585,6 @@ class HomebrewInstaller(Installer):
         ),
     }
 
-    @cached_property
-    def bin_dir(self) -> Path:
-        return Path(readcmd("brew", "--prefix").rstrip(os.linesep)) / "bin"
-
     def install_package(
         self,
         package: str,
@@ -1616,8 +1612,9 @@ class HomebrewInstaller(Installer):
             runcmd("brew", "doctor")
             raise
         ### TODO: Handle variations in this path (Is it "$(brew --prefix)/bin"?)
-        log.debug("Installed program directory: %s", self.bin_dir)
-        return self.bin_dir
+        bin_dir = get_brew_bin_dir()
+        log.debug("Installed program directory: %s", bin_dir)
+        return bin_dir
 
     def assert_supported_system(self, **_kwargs: Any) -> None:
         if shutil.which("brew") is None:
@@ -2963,6 +2960,11 @@ def check_exists(path: Path) -> bool:
                 return True
             sleep(1)
     return os.path.exists(path)
+
+
+@lru_cache()
+def get_brew_bin_dir() -> Path:
+    return Path(readcmd("brew", "--prefix").rstrip(os.linesep)) / "bin"
 
 
 def parse_links(html: str, base_url: Optional[str] = None) -> list[Link]:

--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -28,7 +28,7 @@ from dataclasses import InitVar, dataclass, field
 from email import policy
 from email.headerregistry import ContentTypeHeader
 from enum import Enum
-from functools import total_ordering
+from functools import cached_property, total_ordering
 from getopt import GetoptError, getopt
 from html.parser import HTMLParser
 from http.client import HTTPMessage
@@ -1585,6 +1585,10 @@ class HomebrewInstaller(Installer):
         ),
     }
 
+    @cached_property
+    def bin_dir(self) -> Path:
+        return Path(readcmd("brew", "--prefix").rstrip(os.linesep)) / "bin"
+
     def install_package(
         self,
         package: str,
@@ -1612,8 +1616,8 @@ class HomebrewInstaller(Installer):
             runcmd("brew", "doctor")
             raise
         ### TODO: Handle variations in this path (Is it "$(brew --prefix)/bin"?)
-        log.debug("Installed program directory: /usr/local/bin")
-        return Path("/usr/local/bin")
+        log.debug("Installed program directory: %s", self.bin_dir)
+        return self.bin_dir
 
     def assert_supported_system(self, **_kwargs: Any) -> None:
         if shutil.which("brew") is None:

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -413,7 +413,17 @@ def test_install_git_annex_brew(mocker: MockerFixture) -> None:
     spy = mocker.spy(datalad_installer, "runcmd")
     r = main(["datalad_installer.py", "git-annex", "-m", "brew"])
     assert r == 0
-    assert spy.call_args_list[-1] == mocker.call("brew", "install", "git-annex")
+
+    # where to look for the "brew install" invocation
+    target_index = -1
+    # we might have checked also for the brew --prefix
+    if spy.call_args_list[-1] == mocker.call(
+        "brew", "--prefix", stdout=-1, universal_newlines=True
+    ):
+        target_index -= 1
+    assert spy.call_args_list[target_index] == mocker.call(
+        "brew", "install", "git-annex"
+    )
     assert shutil.which("git-annex") is not None
 
 


### PR DESCRIPTION
expecting that macos-latest testing would not succeed. We might want to add explicitly `macos-12` and then new `macos-latest` which would be arm