### PR TITLE
Temporary pin PyPy versions used in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,11 @@ jobs:
           - '3.11'
           - '3.12'
           - 'pypy-3.8'
-          - 'pypy-3.9'
-          - 'pypy-3.10'
+          # Avoid PyPy 7.3.16, as the tests currently fail on it due to a bug
+          # in it and/or tox: <https://github.com/pypy/pypy/issues/4958>,
+          # <https://github.com/tox-dev/tox/issues/3284>
+          - 'pypy-3.9-v7.3.15'
+          - 'pypy-3.10-v7.3.15'
         toxenv: [py]
         exclude:
           # No older Pythons on arm64 macos-latest


### PR DESCRIPTION
Closes #203.