### PR TITLE
feat(miniconda): --run  to run arbirary commands to possibly tune up that miniconda installation

### DIFF
--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -949,6 +949,13 @@ class MinicondaComponent(Component):
             ),
             Option("--batch", is_flag=True, help="Run in batch (noninteractive) mode"),
             Option(
+                "--run",
+                multiple=True,
+                help="Additional commands to run on an installed conda instance."
+                " If starts with 'conda', uses conda from installed miniconda."
+                " E.g. 'conda config --remove channels defaults' to remove the defaults channel",
+            ),
+            Option(
                 "-c",
                 "--channel",
                 multiple=True,
@@ -980,6 +987,7 @@ class MinicondaComponent(Component):
         self,
         path: Optional[Path] = None,
         batch: bool = False,
+        run: Optional[list[str]] = None,
         spec: Optional[list[str]] = None,
         python_match: Optional[str] = None,
         extra_args: Optional[list[str]] = None,
@@ -1074,6 +1082,12 @@ class MinicondaComponent(Component):
                 "defaults",
                 "conda",
             )
+        for cmd in run or []:
+            cmd_split = shlex.split(cmd)
+            if cmd_split[0] == "conda":
+                runcmd(conda_instance.conda_exe, *cmd_split[1:])
+            else:
+                runcmd(*cmd_split)
         if spec is not None:
             install_args: list[str] = []
             if batch:


### PR DESCRIPTION
This is at large to allow to address some issues which might come up with miniconda installations without waiting to hardcode the workarounds into datalad-installer.  e.g. for 

- #206 

with current change we can address by adding `--run 'conda install libarchive --solver=classic'` ATM, i.e.

```
src/datalad_installer.py -E /tmp/mini1.env miniconda --path /tmp/mini1 --channel conda-forge --python-match minor --batch --run 'conda install libarchive --solver=classic' git-annex -m conda
```

Yet to decide but if to proceed this way, need to 
- [ ] add test