### PR TITLE
Add Python 3.13 as supported

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
           - 'pypy-3.10'
           # Avoid PyPy 7.3.16, as the tests currently fail on it due to a bug
           # in it and/or tox: <https://github.com/pypy/pypy/issues/4958>,

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     License :: OSI Approved :: MIT License


### PR DESCRIPTION
When I enabled conda 3.13 in datalad testing, installation there failed in exciting ways, so decided to see if there are negative effects here.

ref: https://github.com/datalad/datalad/pull/7686