### PR TITLE
Add Python 3.13 as supported

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
           - 'pypy-3.10'
           # Avoid PyPy 7.3.16, as the tests currently fail on it due to a bug
           # in it and/or tox: <https://github.com/pypy/pypy/issues/4958>,

--- a/README.rst
+++ b/README.rst
@@ -322,13 +322,13 @@ Installs git-annex-remote-rclone_.  The component takes an ``-m``, ``--method``
 option specifying the installation method to use; the supported methods are:
 
 .. _git-annex-remote-rclone:
-   https://github.com/DanielDent/git-annex-remote-rclone
+   https://github.com/git-annex-remote-rclone/git-annex-remote-rclone
 
 - ``apt``
 - ``brew``
 - ``conda``
 - ``deb-url``
-- ``DanielDent/git-annex-remote-rclone``
+- ``git-annex-remote-rclone/git-annex-remote-rclone``
 
 If no method is specified, or if the method is set to "``auto``", then the most
 recent component on the command line that provides a compatible installation
@@ -338,7 +338,7 @@ installation method from the following list will be used:
 - ``conda``
 - ``apt``
 - ``brew``
-- ``DanielDent/git-annex-remote-rclone``
+- ``git-annex-remote-rclone/git-annex-remote-rclone``
 
 A specific version to install can be specified for those methods that support
 it by suffixing "``git-annex-remote-rclone``" with "``=``" and the version
@@ -400,7 +400,7 @@ Options
 -e ARGS, --extra-args ARGS      Specify extra command-line arguments to pass to
                                 the installation command.
 
-``DanielDent/git-annex-remote-rclone``
+``git-annex-remote-rclone/git-annex-remote-rclone``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Downloads & installs ``git-annex-remote-rclone`` from a release of its GitHub

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     License :: OSI Approved :: MIT License

--- a/src/datalad_installer.py
+++ b/src/datalad_installer.py
@@ -2300,7 +2300,7 @@ class DMGInstaller(Installer):
 class GARRCGitHubInstaller(Installer):
     """Installs git-annex-remote-rclone from a tag on GitHub"""
 
-    NAME: ClassVar[str] = "DanielDent/git-annex-remote-rclone"
+    NAME: ClassVar[str] = "git-annex-remote-rclone/git-annex-remote-rclone"
 
     OPTIONS: ClassVar[list[Option]] = [
         Option(
@@ -2318,7 +2318,7 @@ class GARRCGitHubInstaller(Installer):
         ),
     }
 
-    REPO: ClassVar[str] = "DanielDent/git-annex-remote-rclone"
+    REPO: ClassVar[str] = "git-annex-remote-rclone/git-annex-remote-rclone"
 
     def install_package(
         self,

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -519,7 +519,7 @@ def test_install_git_annex_remote_rclone_latest_from_github(tmp_path: Path) -> N
             "datalad_installer.py",
             "git-annex-remote-rclone",
             "-m",
-            "DanielDent/git-annex-remote-rclone",
+            "git-annex-remote-rclone/git-annex-remote-rclone",
             "--bin-dir",
             str(tmp_path / "bin"),
         ]
@@ -540,7 +540,7 @@ def test_install_git_annex_remote_rclone_specific_version_from_github(
             "datalad_installer.py",
             "git-annex-remote-rclone=0.5",
             "-m",
-            "DanielDent/git-annex-remote-rclone",
+            "git-annex-remote-rclone/git-annex-remote-rclone",
             "--bin-dir",
             str(tmp_path / "bin"),
         ]
@@ -562,7 +562,7 @@ def test_install_git_annex_remote_rclone_latest_from_github_globally() -> None:
             "--sudo=ok",
             "git-annex-remote-rclone",
             "-m",
-            "DanielDent/git-annex-remote-rclone",
+            "git-annex-remote-rclone/git-annex-remote-rclone",
         ]
     )
     assert r == 0


### PR DESCRIPTION
When I enabled conda 3.13 in datalad testing, installation there failed in exciting ways, so decided to see if there are negative effects here.

ref: https://github.com/datalad/datalad/pull/7686