### PR TITLE
BF(TST): skip datalad-via-pip tests on PyPy 3.10; add PyPy 3.11 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,10 @@ jobs:
           # in it and/or tox: <https://github.com/pypy/pypy/issues/4958>,
           # <https://github.com/tox-dev/tox/issues/3284>
           - 'pypy-3.10-v7.3.15'
+          # PyPy 3.11 still has cryptography wheels, so it actually
+          # exercises `pip install datalad` end-to-end (PyPy 3.10 rows
+          # skip those tests due to the upstream cryptography pp310 drop).
+          - 'pypy-3.11'
         toxenv: [py]
         include:
           - python-version: '3.10'

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -291,6 +291,21 @@ def test_install_venv_miniconda_conda_env_datalad(tmp_path: Path) -> None:
     assert (miniconda_path / "envs" / "foo" / bin_path("datalad")).exists()
 
 
+# `datalad` pulls in `cryptography`, which (since 47.0.0) ships no PyPy
+# 3.10 wheel and refuses to build from sdist on `pp310` ("Unsupported
+# platform: pp73"). Skip the pip-into-venv installation tests under
+# PyPy 3.10 — they cannot succeed regardless of this code. PyPy 3.11+
+# still works because cryptography ships `pp311` wheels.
+no_datalad_pip_on_pypy310 = pytest.mark.skipif(
+    sys.implementation.name == "pypy" and sys.version_info[:2] < (3, 11),
+    reason=(
+        "datalad's cryptography dep has no PyPy 3.10 wheel and the sdist"
+        " rejects pp310 (cryptography >= 47.0.0)"
+    ),
+)
+
+
+@no_datalad_pip_on_pypy310
 def test_install_venv_datalad(tmp_path: Path) -> None:
     venv_path = tmp_path / "venv"
     r = main(
@@ -307,6 +322,7 @@ def test_install_venv_datalad(tmp_path: Path) -> None:
     assert (venv_path / bin_path("datalad")).exists()
 
 
+@no_datalad_pip_on_pypy310
 @pytest.mark.skipif(
     sys.version_info[:2] < (3, 8), reason="dev pip no longer supports Python < 3.8"
 )
@@ -345,6 +361,7 @@ def test_install_venv_pip_git_annex(tmp_path: Path) -> None:
     assert (venv_path / bin_path("git-annex")).exists()
 
 
+@no_datalad_pip_on_pypy310
 @pytest.mark.miniconda
 def test_install_miniconda_conda_env_venv_datalad(tmp_path: Path) -> None:
     venv_path = tmp_path / "venv"


### PR DESCRIPTION
`cryptography` 47.0.0 (released 2026-04-24) ships no `pp310` wheel and the sdist refuses to build under PyPy 3.10
("Unsupported platform: pp73"). `datalad` pulls `cryptography` transitively, so the three pip-into-venv installation tests for `datalad` started failing in nightly cron from 2026-04-25. The git-annex pip path is unaffected (its wheel is `py3-none-...`).

- Skip `test_install_venv_datalad`, `test_install_venv_dev_pip_datalad`, and `test_install_miniconda_conda_env_venv_datalad` when running under PyPy < 3.11, with a reason that points at the upstream cause.
- Add `pypy-3.11` to the test matrix so we keep end-to-end coverage of `pip install datalad`: PyPy 3.11 still has cryptography wheels. Verified locally that all three tests pass cleanly under PyPy 3.11.15 / cryptography 47.0.0.